### PR TITLE
Add Announcement for FEE Registration and Correct Typo Error in Apply FEE Page

### DIFF
--- a/_pe-registration-examinations/Apply for FEE.md
+++ b/_pe-registration-examinations/Apply for FEE.md
@@ -14,7 +14,7 @@ variant: tiptap
 <br>Mechanical engineering – 6 January 2026
 <br>Chemical engineering – 7 January 2026
 <br>Civil engineering – 7 January 2026</p>
-<p>For information on FEE 2026, please refer to <a href="/files/Downloads/Info on Exams/fee_2026.pdf" rel="noopener nofollow" target="_blank">Informafiletion for Applicants – Fundamentals of Engineering Examination 2026</a>
+<p>For information on FEE 2026, please refer to <a href="/files/Downloads/Info on Exams/fee_2026.pdf" rel="noopener nofollow" target="_blank">Information for Applicants – Fundamentals of Engineering Examination 2026</a>
 <br>
 <br>For guidance on the application process, please refer to the <a href="/files/Downloads/Info on Exams/Application_Guide_for_FEE_2026.pdf" rel="noopener nofollow" target="_blank">Application Guide for FEE 2026</a>
 <a href="/files/Downloads/Info on Exams/application_guide_for_fee_2025.pdf" rel="noopener nofollow" target="_blank">.</a>

--- a/news/announcements/_posts/2025-07-01-link-FEE 2026 Registration Opens 1 July 2025.md
+++ b/news/announcements/_posts/2025-07-01-link-FEE 2026 Registration Opens 1 July 2025.md
@@ -1,0 +1,9 @@
+---
+title: FEE 2026 Registration Opens 1 July 2025
+date: 2025-07-01
+layout: link
+description: ""
+image: ""
+variant: tiptap
+external: https://www1.peb.gov.sg/apply4fee/
+---


### PR DESCRIPTION
- Added an announcement - "FEE 2026 Registration Opens 1 July 2025" which will redirect to Apply FEE Page
- Correct typo error, "Informafiletion" to "Information" in Apply FEE Page